### PR TITLE
Add XdgDocumentsPortal

### DIFF
--- a/example/documents.dart
+++ b/example/documents.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
+
+// Use `flatpak documents --columns=all` to show current documents
+
+void usage() {
+  print('Usage:');
+  print('documents get-mount-point');
+  print('documents add <path>');
+  print('documents grant-permissions <doc-id> <app-id> <permissions>');
+  print('documents revoke-permissions <doc-id> <app-id> <permissions>');
+  print('documents delete <doc-id>');
+}
+
+void main(List<String> args) async {
+  if (args.isEmpty) {
+    usage();
+    return;
+  }
+  var command = args[0];
+
+  var client = XdgDesktopPortalClient();
+
+  switch (command) {
+    case 'get-mount-point':
+      var mountPoint = await client.documents.getMountPoint();
+      print(mountPoint.path);
+      break;
+    case 'add':
+      if (args.length < 2) {
+        usage();
+      } else {
+        var path = args[1];
+        var docId = await client.documents.add([File(path)]);
+        print(docId[0]);
+      }
+      break;
+    case 'grant-permissions':
+      if (args.length < 4) {
+        usage();
+      } else {
+        var docId = args[1];
+        var appId = args[2];
+        var permissions = parsePermissions(args.sublist(3));
+        if (permissions != null) {
+          await client.documents.grantPermissions(docId, appId, permissions);
+        }
+      }
+      break;
+    case 'revoke-permissions':
+      if (args.length < 4) {
+        usage();
+      } else {
+        var docId = args[1];
+        var appId = args[2];
+        var permissions = parsePermissions(args.sublist(3));
+        if (permissions != null) {
+          await client.documents.revokePermissions(docId, appId, permissions);
+        }
+      }
+      break;
+    case 'delete':
+      if (args.length < 2) {
+        usage();
+      } else {
+        var docId = args[1];
+        await client.documents.delete(docId);
+      }
+      break;
+    default:
+      usage();
+      break;
+  }
+
+  await client.close();
+}
+
+Set<XdgDocumentPermission>? parsePermissions(Iterable<String> permissionNames) {
+  var permissions = <XdgDocumentPermission>{};
+  for (var name in permissionNames) {
+    var permission = {
+      'read': XdgDocumentPermission.read,
+      'write': XdgDocumentPermission.write,
+      'grant-permissions': XdgDocumentPermission.grantPermissions,
+      'delete': XdgDocumentPermission.delete
+    }[name];
+    if (permission == null) {
+      print("Unknown permission '$name'");
+      usage();
+      return null;
+    }
+    permissions.add(permission);
+  }
+  return permissions;
+}

--- a/lib/src/xdg_desktop_portal_client.dart
+++ b/lib/src/xdg_desktop_portal_client.dart
@@ -6,6 +6,7 @@ import 'package:dbus/dbus.dart';
 import 'xdg_account_portal.dart';
 import 'xdg_background_portal.dart';
 import 'xdg_camera_portal.dart';
+import 'xdg_documents_portal.dart';
 import 'xdg_email_portal.dart';
 import 'xdg_file_chooser_portal.dart';
 import 'xdg_network_monitor_portal.dart';
@@ -22,7 +23,8 @@ class XdgDesktopPortalClient {
   final DBusClient _bus;
   final bool _closeBus;
 
-  late final DBusRemoteObject _object;
+  late final DBusRemoteObject _desktopObject;
+  late final DBusRemoteObject _documentsObject;
 
   /// Portal for obtaining information about the user.
   late final XdgAccountPortal account;
@@ -32,6 +34,9 @@ class XdgDesktopPortalClient {
 
   /// Camera portal.
   late final XdgCameraPortal camera;
+
+  /// Portal to access documents.
+  late final XdgDocumentsPortal documents;
 
   /// Portal to send email.
   late final XdgEmailPortal email;
@@ -67,21 +72,25 @@ class XdgDesktopPortalClient {
   XdgDesktopPortalClient({DBusClient? bus})
       : _bus = bus ?? DBusClient.session(),
         _closeBus = bus == null {
-    _object = DBusRemoteObject(_bus,
+    _desktopObject = DBusRemoteObject(_bus,
         name: 'org.freedesktop.portal.Desktop',
         path: DBusObjectPath('/org/freedesktop/portal/desktop'));
-    account = XdgAccountPortal(_object, _generateToken);
-    background = XdgBackgroundPortal(_object, _generateToken);
-    camera = XdgCameraPortal(_object, _generateToken);
-    email = XdgEmailPortal(_object, _generateToken);
-    fileChooser = XdgFileChooserPortal(_object, _generateToken);
-    location = XdgLocationPortal(_object, _generateToken);
-    networkMonitor = XdgNetworkMonitorPortal(_object);
-    notification = XdgNotificationPortal(_object);
-    openUri = XdgOpenUriPortal(_object, _generateToken);
-    proxyResolver = XdgProxyResolverPortal(_object);
-    secret = XdgSecretPortal(_object, _generateToken);
-    settings = XdgSettingsPortal(_object);
+    _documentsObject = DBusRemoteObject(_bus,
+        name: 'org.freedesktop.portal.Documents',
+        path: DBusObjectPath('/org/freedesktop/portal/documents'));
+    account = XdgAccountPortal(_desktopObject, _generateToken);
+    background = XdgBackgroundPortal(_desktopObject, _generateToken);
+    camera = XdgCameraPortal(_desktopObject, _generateToken);
+    documents = XdgDocumentsPortal(_documentsObject);
+    email = XdgEmailPortal(_desktopObject, _generateToken);
+    fileChooser = XdgFileChooserPortal(_desktopObject, _generateToken);
+    location = XdgLocationPortal(_desktopObject, _generateToken);
+    networkMonitor = XdgNetworkMonitorPortal(_desktopObject);
+    notification = XdgNotificationPortal(_desktopObject);
+    openUri = XdgOpenUriPortal(_desktopObject, _generateToken);
+    proxyResolver = XdgProxyResolverPortal(_desktopObject);
+    secret = XdgSecretPortal(_desktopObject, _generateToken);
+    settings = XdgSettingsPortal(_desktopObject);
   }
 
   /// Terminates all active connections. If a client remains unclosed, the Dart process may not terminate.

--- a/lib/src/xdg_documents_portal.dart
+++ b/lib/src/xdg_documents_portal.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dbus/dbus.dart';
+
+/// Permissions that can be assigned to documents.
+enum XdgDocumentPermission { read, write, grantPermissions, delete }
+
+final _permissionToString = {
+  XdgDocumentPermission.read: 'read',
+  XdgDocumentPermission.write: 'write',
+  XdgDocumentPermission.grantPermissions: 'grant-permissions',
+  XdgDocumentPermission.delete: 'delete'
+};
+
+/// Portal to access documents.
+class XdgDocumentsPortal {
+  final DBusRemoteObject _object;
+
+  XdgDocumentsPortal(this._object);
+
+  /// Get the version of this portal.
+  Future<int> getVersion() => _object
+      .getProperty('org.freedesktop.portal.Documents', 'version',
+          signature: DBusSignature('u'))
+      .then((v) => v.asUint32());
+
+  /// Returns the path at which the document store fuse filesystem is mounted. This will typically be `/run/user/$UID/doc/`.
+  Future<Directory> getMountPoint() async {
+    var result = await _object.callMethod(
+        'org.freedesktop.portal.Documents', 'GetMountPoint', [],
+        replySignature: DBusSignature('ay'));
+    return Directory.fromRawPath(
+        Uint8List.fromList(result.values[0].asByteArray().toList()));
+  }
+
+  /// Adds files to the document store.
+  /// Returns the document IDs for these document.
+  Future<List<String>> add(Iterable<File> files,
+      {bool reuseExisting = false,
+      bool persistent = false,
+      bool asNeededByApp = false,
+      bool exportDirectory = false,
+      String appId = '',
+      Set<XdgDocumentPermission> permissions = const {}}) async {
+    var openedFiles = <RandomAccessFile>[];
+    for (var file in files) {
+      openedFiles.add(await file.open());
+    }
+    var flags = 0;
+    if (reuseExisting) {
+      flags |= 0x1;
+    }
+    if (persistent) {
+      flags |= 0x2;
+    }
+    if (asNeededByApp) {
+      flags |= 0x4;
+    }
+    if (exportDirectory) {
+      flags |= 0x8;
+    }
+    var result = await _object.callMethod(
+        'org.freedesktop.portal.Documents',
+        'AddFull',
+        [
+          DBusArray.unixFd(openedFiles.map((f) => ResourceHandle.fromFile(f))),
+          DBusUint32(flags),
+          DBusString(appId),
+          DBusArray.string(permissions.map((p) => _permissionToString[p] ?? ''))
+        ],
+        replySignature: DBusSignature('asa{sv}'));
+    for (var f in openedFiles) {
+      await f.close();
+    }
+    return result.returnValues[0].asStringArray().toList();
+  }
+
+  /// Grants access permissions for a file with [docId] to the application with [appId].
+  Future<void> grantPermissions(String docId, String appId,
+      Set<XdgDocumentPermission> permissions) async {
+    await _object.callMethod(
+        'org.freedesktop.portal.Documents',
+        'GrantPermissions',
+        [
+          DBusString(docId),
+          DBusString(appId),
+          DBusArray.string(permissions.map((p) => _permissionToString[p] ?? ''))
+        ],
+        replySignature: DBusSignature(''));
+  }
+
+  /// Revokes access permissions for a file with [docId] from the application with [appId].
+  Future<void> revokePermissions(String docId, String appId,
+      Set<XdgDocumentPermission> permissions) async {
+    await _object.callMethod(
+        'org.freedesktop.portal.Documents',
+        'RevokePermissions',
+        [
+          DBusString(docId),
+          DBusString(appId),
+          DBusArray.string(permissions.map((p) => _permissionToString[p] ?? ''))
+        ],
+        replySignature: DBusSignature(''));
+  }
+
+  /// Removes an entry from the document store. The file itself is not deleted.
+  Future<void> delete(String docId) async {
+    await _object.callMethod(
+        'org.freedesktop.portal.Documents', 'Delete', [DBusString(docId)],
+        replySignature: DBusSignature(''));
+  }
+}

--- a/lib/xdg_desktop_portal.dart
+++ b/lib/xdg_desktop_portal.dart
@@ -1,6 +1,7 @@
 export 'src/xdg_account_portal.dart';
 export 'src/xdg_background_portal.dart';
 export 'src/xdg_desktop_portal_client.dart';
+export 'src/xdg_documents_portal.dart';
 export 'src/xdg_email_portal.dart';
 export 'src/xdg_file_chooser_portal.dart';
 export 'src/xdg_network_monitor_portal.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ platforms:
 
 dependencies:
   collection: ^1.15.0
-  dbus: ^0.7.7
+  dbus: ^0.7.8
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
The Lookup, Info and List methods are not implemented - these calls are not available from inside a sandbox and are thus not likely to be used in Dart applications.

The AddNamed method is not implemented, this requires a file descriptor for a directory, which is not possible in Dart currently (files only).

Fixes https://github.com/canonical/xdg_desktop_portal.dart/issues/26